### PR TITLE
Add support for Aerotenna uSharp sensor

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -10,6 +10,14 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ENABLE", 1,  AC_Avoid, _enabled, AC_AVOID_ALL),
 
+    // @Param: DIST
+    // @DisplayName: Avoidance standoff distance
+    // @Description: Distance to maintain from obstacle
+    // @Units: cm
+    // @Values: 0 1000.0
+    // @User: Standard
+    AP_GROUPINFO("DIST", 2,  AC_Avoid, _avoid_dist, AVOID_DIST_DEFAULT),
+
     AP_GROUPEND
 };
 
@@ -182,7 +190,7 @@ void AC_Avoid::adjust_velocity_proximity(const float kP, const float accel_cmss,
     // get nearest object using body-frame angle and shorten desired velocity (which must remain in earth-frame)
     float distance_m;
     if (_proximity.get_horizontal_distance(degrees(heading_bf_rad), distance_m)) {
-        limit_velocity(kP, accel_cmss, desired_vel, vel_dir, MAX(distance_m*100.0f - 200.0f, 0.0f));
+        limit_velocity(kP, accel_cmss, desired_vel, vel_dir, MAX(distance_m*100.0f - _avoid_dist, 0.0f));
     }
 }
 

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -17,6 +17,9 @@
 #define AC_AVOID_USE_PROXIMITY_SENSOR   2       // stop based on proximity sensor output
 #define AC_AVOID_ALL                    3       // use fence and promiximity sensor
 
+// parameter defaults
+#define AVOID_DIST_DEFAULT  250.0f // default avoidance standoff distance
+
 /*
  * This class prevents the vehicle from leaving a polygon fence in
  * 2 dimensions by limiting velocity (adjust_velocity).
@@ -91,5 +94,6 @@ private:
     const AP_Proximity& _proximity;
 
     // parameters
-    AP_Int8 _enabled;
+    AP_Int8  _enabled;
+    AP_Float _avoid_dist;
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -15,6 +15,7 @@
 
 #include "AP_Proximity.h"
 #include "AP_Proximity_LightWareSF40C.h"
+#include "AP_Proximity_uSharp.h"
 #include "AP_Proximity_SITL.h"
 
 extern const AP_HAL::HAL &hal;
@@ -26,7 +27,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Proximity type
     // @Description: What type of proximity sensor is connected
-    // @Values: 0:None,1:LightWareSF40C
+    // @Values: 0:None,1:LightWareSF40C,2:Aerotenna_uSharp
     // @User: Standard
     AP_GROUPINFO("_TYPE",   1, AP_Proximity, _type[0], 0),
 
@@ -48,7 +49,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second Proximity type
     // @Description: What type of proximity sensor is connected
-    // @Values: 0:None,1:LightWareSF40C
+    // @Values: 0:None,1:LightWareSF40C,2:Aerotenna_uSharp
     // @User: Advanced
     AP_GROUPINFO("2_TYPE", 4, AP_Proximity, _type[1], 0),
 
@@ -165,6 +166,13 @@ void AP_Proximity::detect_instance(uint8_t instance)
         if (AP_Proximity_LightWareSF40C::detect(serial_manager)) {
             state[instance].instance = instance;
             drivers[instance] = new AP_Proximity_LightWareSF40C(*this, state[instance], serial_manager);
+            return;
+        }
+    }
+    if (type == Proximity_Type_USHARP) {
+        if (AP_Proximity_uSharp::detect(serial_manager)) {
+            state[instance].instance = instance;
+            drivers[instance] = new AP_Proximity_uSharp(*this, state[instance], serial_manager);
             return;
         }
     }

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -35,9 +35,10 @@ public:
 
     // Proximity driver types
     enum Proximity_Type {
-        Proximity_Type_None  = 0,
-        Proximity_Type_SF40C = 1,
-        Proximity_Type_SITL  = 10,
+        Proximity_Type_None   = 0,
+        Proximity_Type_SF40C  = 1,
+        Proximity_Type_USHARP = 2,
+        Proximity_Type_SITL   = 10,
     };
 
     enum Proximity_Status {

--- a/libraries/AP_Proximity/AP_Proximity_uSharp.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_uSharp.cpp
@@ -1,0 +1,193 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_Proximity_uSharp.h"
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <ctype.h>
+#include <stdio.h>
+
+extern const AP_HAL::HAL& hal;
+
+/* 
+   The constructor also initialises the proximity sensor. Note that this
+   constructor is not called until detect() returns true, so we
+   already know that we should setup the proximity sensor
+*/
+AP_Proximity_uSharp::AP_Proximity_uSharp(AP_Proximity &_frontend,
+                                         AP_Proximity::Proximity_State &_state,
+                                         AP_SerialManager &serial_manager) :
+    AP_Proximity_Backend(_frontend, _state)
+{
+    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Aerotenna_uSharp, 0);
+    if (uart != nullptr) {
+        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Aerotenna_uSharp, 0));
+    }
+
+    // initialize variables dependent on number of uSharp panels
+    for (uint8_t i=0; i<_num_sectors; i++) {
+        // calculate middle angle of each sector based on number of panels
+        _sector_middle_deg[i] = i * (M_2PI / _num_sectors);
+
+        // set width (in deg) for each sector
+        _sector_width_deg[i] = PROXIMITY_USHARP_SECTOR_WIDTH_DEG;
+    }
+}
+
+// detect if a Aerotenna proximity sensor is connected by looking for a configured serial port
+bool AP_Proximity_uSharp::detect(AP_SerialManager &serial_manager)
+{
+    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Aerotenna_uSharp, 0) != nullptr;
+}
+
+// get distance in meters in a particular direction in degrees (0 is forward, angles increase in the clockwise direction)
+bool AP_Proximity_uSharp::get_horizontal_distance(float angle_deg, float &distance) const
+{
+    uint8_t sector;
+    if (convert_angle_to_sector(angle_deg, sector)) {
+        if (_distance_valid[sector]) {
+            distance = _distance[sector] / 100.0f; // convert from cm to meters
+            return true;
+        }
+    }
+    return false;
+}
+
+// update the state of the sensor
+void AP_Proximity_uSharp::update(void)
+{
+    if (uart == nullptr) {
+        return;
+    }
+
+    // read uSharp
+    if (get_reading()) {
+        set_status(AP_Proximity::Proximity_Good);
+    }else{
+        set_status(AP_Proximity::Proximity_NoData);
+    }
+}
+
+// return last value measured by uSharp sensor
+// note: reading is distance in cm
+bool AP_Proximity_uSharp::get_reading(void)
+{
+    // read any available lines from the uLanding
+    float sum[4] = {0,};
+    uint16_t count[4] = {0,};
+    uint8_t  index = 0;
+
+    int16_t nbytes = uart->available();
+    while (nbytes-- > 0) {
+        uint8_t c = uart->read();
+        // ok, we have located start byte
+        if ( c == 72 && index ==0 ) {
+            linebuf_len = 0;
+            index       = 1;
+        }
+        // now it is ready to decode index information
+        if ( index == 1 ){
+        	linebuf[linebuf_len] = c;
+        	linebuf_len ++;
+        	if ( linebuf_len == 4 ){
+        		index = 0;
+        		switch(linebuf[1]){
+        		case 252:
+        			sum[3] += ( linebuf[3]&0x7F ) *128 + ( linebuf[2]&0x7F );
+        			count[3]++;
+        			break;
+        		case 253:
+        			sum[0] += ( linebuf[3]&0x7F ) *128 + ( linebuf[2]&0x7F );
+        			count[0]++;
+        			break;
+        		case 254:
+        			sum[1] += ( linebuf[3]&0x7F ) *128 + ( linebuf[2]&0x7F );
+        			count[1]++;
+        			break;
+        		default:
+        			sum[2] += ( linebuf[3]&0x7F ) *128 + ( linebuf[2]&0x7F );
+        			count[2]++;
+        		}
+
+        		linebuf_len = 0;
+        	}
+        }
+
+    }
+
+    if ( count[0] == 0 && count[1] == 0 && count[2] == 0 && count[3] == 0 ) {
+        _last_distance_received_ms = 0;
+        return false;
+    }
+
+    for (uint8_t i=0; i<_num_sectors; i++) {
+        if ( count[i] != 0 ){
+        	_distance[i] = USHARP_MEASUREMENT_COEFFICIENT * sum[i] / count[i];
+            _distance_valid[i] = true;
+            _last_distance_received_ms = AP_HAL::millis();
+        }else{
+            _distance_valid[i] = false;
+        }
+    }
+
+    // check for timeout
+    if ((_last_distance_received_ms == 0) || (AP_HAL::millis() - _last_distance_received_ms > PROXIMITY_USHARP_TIMEOUT_MS)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool AP_Proximity_uSharp::convert_angle_to_sector(float angle_degrees, uint8_t &sector) const
+{
+    // sanity check angle
+    if (angle_degrees > 360.0f || angle_degrees < -180.0f) {
+        return false;
+    }
+
+    // convert to 0 ~ 360
+    if (angle_degrees < 0.0f) {
+        angle_degrees += 360.0f;
+    }
+
+    bool closest_found = false;
+    uint8_t closest_sector;
+    float closest_angle;
+
+    // search for which sector angle_degrees falls into
+    for (uint8_t i = 0; i < _num_sectors; i++) {
+        float angle_diff = fabsf(wrap_180(_sector_middle_deg[i] - angle_degrees));
+
+        // record if closest
+        if (!closest_found || angle_diff < closest_angle) {
+            closest_found = true;
+            closest_sector = i;
+            closest_angle = angle_diff;
+        }
+
+        if (fabsf(angle_diff) <= _sector_width_deg[i] / 2.0f) {
+            sector = i;
+            return true;
+        }
+    }
+
+    // angle_degrees might have been within a gap between sectors
+    if (closest_found) {
+        sector = closest_sector;
+        return true;
+    }
+
+    return false;
+}

--- a/libraries/AP_Proximity/AP_Proximity_uSharp.h
+++ b/libraries/AP_Proximity/AP_Proximity_uSharp.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "AP_Proximity.h"
+#include "AP_Proximity_Backend.h"
+
+#define PROXIMITY_USHARP_PANELS            4                              // maximum number of sectors
+#define PROXIMITY_USHARP_SECTOR_WIDTH_DEG  (360/PROXIMITY_USHARP_PANELS)  // angular width of each sector
+#define PROXIMITY_USHARP_TIMEOUT_MS        200                            // requests timeout after 0.2 seconds
+#define USHARP_MEASUREMENT_COEFFICIENT     2.5f
+
+class AP_Proximity_uSharp : public AP_Proximity_Backend
+{
+
+public:
+    // constructor
+    AP_Proximity_uSharp(AP_Proximity &_frontend, AP_Proximity::Proximity_State &_state, AP_SerialManager &serial_manager);
+
+    // static detection function
+    static bool detect(AP_SerialManager &serial_manager);
+
+    // get distance in meters in a particular direction in degrees (0 is forward, clockwise)
+    // returns true on successful read and places distance in distance
+    bool get_horizontal_distance(float angle_deg, float &distance) const;
+
+    // update state
+    void update(void);
+
+private:
+
+    // read data from sensor
+    bool get_reading(void);
+    bool convert_angle_to_sector(float angle_degrees, uint8_t &sector) const;
+
+    AP_HAL::UARTDriver *uart = nullptr;
+    uint32_t _last_distance_received_ms;    // system time of last distance measurement received from sensor
+    uint8_t linebuf[10];
+    uint8_t linebuf_len;
+
+    // sensor data
+    uint8_t  _num_sectors = PROXIMITY_USHARP_PANELS;      // number of sectors we will search
+    uint16_t _sector_middle_deg[PROXIMITY_USHARP_PANELS]; // middle angle of each sector
+    uint8_t  _sector_width_deg[PROXIMITY_USHARP_PANELS];  // width (in degrees) of each sector
+    float    _angle[PROXIMITY_USHARP_PANELS];             // angle to closest object within each sector
+    float    _distance[PROXIMITY_USHARP_PANELS];          // distance to closest object within each sector
+    bool     _distance_valid[PROXIMITY_USHARP_PANELS];    // true if a valid distance received for each sector
+};

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 12:uLanding, 13:uSharp
     // @User: Standard
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
 
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 12:uLanding, 13:uSharp
     // @User: Standard
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SerialProtocol_MAVLink),
 
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 12:uLanding, 13:uSharp
     // @User: Standard
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SerialProtocol_GPS),
 
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 12:uLanding, 13:uSharp
     // @User: Standard
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SerialProtocol_GPS),
 
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 5_PROTOCOL
     // @DisplayName: Serial5 protocol selection
     // @Description: Control what protocol Serial5 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360
+    // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 12:uLanding, 13:uSharp
     // @User: Standard
     AP_GROUPINFO("5_PROTOCOL",  9, AP_SerialManager, state[5].protocol, SERIAL5_PROTOCOL),
 
@@ -200,6 +200,13 @@ void AP_SerialManager::init()
                                          AP_SERIALMANAGER_SToRM32_BUFSIZE_TX);
                     break;
                 case SerialProtocol_Aerotenna_uLanding:
+                    // Note baudrate is hardcoded to 115200
+                    state[i].baud = AP_SERIALMANAGER_ULANDING_BAUD / 1000;   // update baud param in case user looks at it
+                    state[i].uart->begin(map_baudrate(state[i].baud),
+                                         AP_SERIALMANAGER_ULANDING_BUFSIZE_RX,
+                                         AP_SERIALMANAGER_ULANDING_BUFSIZE_TX);
+                    break;
+                case SerialProtocol_Aerotenna_uSharp:
                     // Note baudrate is hardcoded to 115200
                     state[i].baud = AP_SERIALMANAGER_ULANDING_BAUD / 1000;   // update baud param in case user looks at it
                     state[i].uart->begin(map_baudrate(state[i].baud),

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -63,7 +63,7 @@
 #define AP_SERIALMANAGER_SToRM32_BUFSIZE_RX     128
 #define AP_SERIALMANAGER_SToRM32_BUFSIZE_TX     128
 
-// Aerotenne uLanding Altimeter
+// Aerotenna uLanding Altimeter
 // Note that size of UART FIFO is 128 for Altera-OcPoc board
 #define AP_SERIALMANAGER_ULANDING_BAUD           115200
 #define AP_SERIALMANAGER_ULANDING_BUFSIZE_RX     128
@@ -88,7 +88,8 @@ public:
         SerialProtocol_Lidar = 9,
         SerialProtocol_FrSky_SPort_Passthrough = 10, // FrSky SPort Passthrough (OpenTX) protocol (X-receivers)
         SerialProtocol_Lidar360 = 11,
-        SerialProtocol_Aerotenna_uLanding      = 12, // Ulanding support
+        SerialProtocol_Aerotenna_uLanding      = 12, // Aerotenna uLanding support
+        SerialProtocol_Aerotenna_uSharp        = 13, // Aerotenna uSharp support
     };
 
     // Constructor


### PR DESCRIPTION
AP_Proximity: Adds the necessary serial protocol and AP_Proximity backend to support the Aerotenna uSharp sensor.

AC_Avoidance: Adds user-defined parameter for the standoff distance for avoidance with a proximity sensor.
